### PR TITLE
docs(#5): backlink PRD to Ravely AgDR-0001..0003

### DIFF
--- a/projects/ravely/prd-v1.md
+++ b/projects/ravely/prd-v1.md
@@ -352,15 +352,15 @@ The EU Database Directive 96/9/EC grants a sui generis right that prohibits subs
 
 ### Technical Decisions Requiring AgDRs
 
-Per `.claude/rules/agdr-decisions.md`, the following need AgDRs written at Tech Design time:
+Per `.claude/rules/agdr-decisions.md`, the following need AgDRs written at Tech Design time. AgDRs live in the Ravely product repo (`mrshousha/ravely`) at `docs/agdr/`, because they bind to implementation decisions and should ship with the code.
 
-1. **Scrape-first data-source strategy** — trade-off vs. API-only / partnership-first; legal mitigations; kill-switch design; must record EU Database Directive considerations
-2. **Data pipeline architecture** (cron-triggered Vercel function vs. separate worker vs. GitHub Actions scheduled job)
-3. **Scraper adapter interface** — single adapter pattern spanning REST / HTML / RSS / iCal sources
-4. **Event dedup algorithm** (exact match vs. fuzzy venue + time tolerance)
-5. **DJ slug generation** (how to handle name collisions, special characters, multiple aliases)
-6. **Rendering strategy per page type** (SSG vs. SSR vs. ISR trade-offs)
-7. **Ad integration decision** (AdSense vs. Ezoic vs. direct; deferred until post-launch traffic)
+1. ✅ [**AgDR-0001 — Scrape-first data-source strategy**](https://github.com/mrshousha/ravely/blob/main/docs/agdr/AgDR-0001-scrape-first-data-strategy.md) (accepted 2026-04-24) — trade-off vs. API-only / partnership-first; EU Database Directive mitigations; 24h takedown SLO; permanent no-scrape list.
+2. ✅ [**AgDR-0002 — Data pipeline architecture**](https://github.com/mrshousha/ravely/blob/main/docs/agdr/AgDR-0002-data-pipeline-architecture.md) (accepted 2026-04-24) — GitHub Actions scheduled workflows → Vercel Postgres via a shared ingest package. Free-tier; 2-hour cadence.
+3. ✅ [**AgDR-0003 — Scraper adapter interface**](https://github.com/mrshousha/ravely/blob/main/docs/agdr/AgDR-0003-scraper-adapter-interface.md) (accepted 2026-04-24) — single `EventSourceAdapter` + `runAdapter` runner. Runner owns every AgDR-0001 mitigation; adapters are plain objects with `listUrls` + `parse`; blocklist enforced mechanically.
+4. ⏳ **AgDR-0004 — Event dedup algorithm** (pending) — exact match vs. fuzzy venue + time tolerance.
+5. ⏳ **AgDR-0005 — DJ slug generation** (pending) — handling name collisions, special characters, multiple aliases.
+6. ⏳ **AgDR-0006 — Rendering strategy per page type** (pending) — SSG vs. SSR vs. ISR trade-offs across event / DJ / venue / city / genre routes.
+7. ⏳ **AgDR-0007 — Ad integration decision** (deferred until post-launch traffic) — AdSense vs. Ezoic vs. direct; gated on reaching ~1k visitors/month.
 
 ---
 


### PR DESCRIPTION
## Summary

- Updates § "Technical Decisions Requiring AgDRs" in `projects/ravely/prd-v1.md` with cross-repo links to the three AgDRs merged in `mrshousha/ravely#2`
- Pending AgDRs (0004, 0005, 0006, 0007) retained with ⏳ prefix
- Adds a one-line note clarifying that AgDRs live in the product repo — the ops-fork PRD is the index, not the storage

## Testing

1. Open `projects/ravely/prd-v1.md` in the rendered markdown — the three AgDR entries are clickable and resolve to the right files on `mrshousha/ravely`
2. Pending AgDRs (0004-0007) remain listed without links

## Glossary

| Term | Definition |
|------|------------|
| Cross-repo link | A link from one GitHub repo to another (here: from this ops fork's PRD to Ravely's AgDRs). Unlike in-repo relative links, these never break on branch rename — but they also bypass GitHub's file-rename tracking. |
| AgDR | Agent Decision Record — Ravely's analogue of an ADR; lives in `docs/agdr/` in the product repo. |

Closes #5
Refs mrshousha/ravely#1

🤖 Generated with [Claude Code](https://claude.com/claude-code)