### PR TITLE
fix(#7): per-repo marker namespace + --repo-aware hook resolution

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -175,7 +175,7 @@ Resolve each piece:
 
 ```bash
 # Ops fork root: the dir containing onboarding.yaml, walking up from cwd
-OPS_FORK=$(r="$PWD"; while [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do r="${r%/*}"; done; echo "$r")
+OPS_FORK=$(r="$PWD"; while [ -n "$r" ] && [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do r="${r%/*}"; done; [ -n "$r" ] && [ -f "$r/onboarding.yaml" ] && echo "$r")
 
 # Target repo: owner/repo of the PR you reviewed (authoritative: gh api)
 OWNER_REPO=$(gh pr view {number} --repo <hint-if-known> --json headRepositoryOwner,headRepository \

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -163,22 +163,42 @@ This PR cannot be merged until technical decisions are documented.
 
 When your verdict is APPROVED, and ONLY then, write the approval marker file so the `block-unreviewed-merge.sh` hook can let the merge through.
 
-### The command
+### Where to write
 
-Use exactly one of these forms. Nothing else:
+Markers are per-repo and anchored at the **ops-fork root** (see #7). The hook walks up from the merge command's cwd to find `onboarding.yaml`, then resolves the target repo from `--repo` or the cwd's origin. Your marker must be at the same path the hook will look:
 
-```bash
-# Option A — from the local HEAD of the PR branch
-git rev-parse HEAD > .claude/session/reviews/{number}-rex.approved
-
-# Option B — from the PR's HEAD on GitHub (preferred for cross-repo / detached HEAD)
-gh pr view {number} --json headRefOid --jq .headRefOid > .claude/session/reviews/{number}-rex.approved
-
-# Option C — literal SHA write (when you've already captured the SHA in a variable)
-printf '%s\n' "$SHA" > .claude/session/reviews/{number}-rex.approved
+```
+<ops-fork-root>/.claude/session/reviews/<owner>/<repo>/<pr>-rex.approved
 ```
 
-Where `{number}` is the PR number and the file path is repo-relative from the repo root.
+Resolve each piece:
+
+```bash
+# Ops fork root: the dir containing onboarding.yaml, walking up from cwd
+OPS_FORK=$(r="$PWD"; while [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do r="${r%/*}"; done; echo "$r")
+
+# Target repo: owner/repo of the PR you reviewed (authoritative: gh api)
+OWNER_REPO=$(gh pr view {number} --repo <hint-if-known> --json headRepositoryOwner,headRepository \
+  --jq '.headRepositoryOwner.login + "/" + .headRepository.name')
+
+REVIEWS_DIR="$OPS_FORK/.claude/session/reviews/$OWNER_REPO"
+mkdir -p "$REVIEWS_DIR"
+```
+
+### The command
+
+Use one of these forms:
+
+```bash
+# Preferred — ask GitHub for the authoritative HEAD SHA of the PR you reviewed
+gh pr view {number} --repo "$OWNER_REPO" --json headRefOid --jq '.headRefOid' \
+  > "$REVIEWS_DIR/{number}-rex.approved"
+
+# Alternative — you already captured the SHA in a variable during review
+printf '%s\n' "$SHA" > "$REVIEWS_DIR/{number}-rex.approved"
+```
+
+**Do not** use `git rev-parse HEAD` — the local HEAD is almost never the PR branch's HEAD, so the marker will fail the hook's SHA-match check.
 
 ### Content — MUST be bare SHA + newline
 
@@ -212,10 +232,6 @@ APPROVED at 2933a06e28a1e98aee8cdef18a0dcaaa0f610b08
 ```
 
 All of these fail the hook's whitespace-strip-then-compare check. The merge gate blocks the PR; the only way forward is hand-editing the marker, which is itself a rule violation per `.claude/rules/pr-workflow.md` § "Mechanical enforcement". Don't create that situation.
-
-### Where to write
-
-`.claude/session/reviews/` at the repo root. If running in a nested worktree, write to the worktree's reviews dir — that's where the merge-gate hook looks.
 
 ### On REQUEST CHANGES or COMMENT verdicts
 
@@ -271,7 +287,7 @@ Report the failure in plain text with the exact command the caller needs to run.
    - REQUEST CHANGES with the specific decisions you detected
    - List what needs to be documented
    - The PR author must run `/decide` and link the AgDR before re-review
-8. **Approval marker format is BLOCKING** — on APPROVED verdicts, write the marker at `.claude/session/reviews/{pr}-rex.approved` containing exactly the 40-char HEAD SHA + newline. No labels, no JSON, no extra text. See the "Approval marker — EXACT FORMAT REQUIRED" section above. A malformed marker blocks the merge and forces a rule-violating hand-edit, so getting the format right is as important as the review content.
+8. **Approval marker format is BLOCKING** — on APPROVED verdicts, write the marker at `<ops-fork>/.claude/session/reviews/<owner>/<repo>/{pr}-rex.approved` (per-repo namespace, #7) containing exactly the 40-char HEAD SHA + newline. No labels, no JSON, no extra text. See the "Approval marker — EXACT FORMAT REQUIRED" section above. A malformed marker blocks the merge and forces a rule-violating hand-edit, so getting the format right is as important as the review content.
 
 ## Example Invocation
 

--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -210,7 +210,7 @@ The hook reads the marker, strips whitespace, and compares to the PR's HEAD SHA.
 2933a06e28a1e98aee8cdef18a0dcaaa0f610b08
 ```
 
-41 bytes: 40 hex + `\n`. No labels, no keys, no timestamp, no trailing text. Confirm with `od -c .claude/session/reviews/{number}-rex.approved | head -2` — the first two bytes of the second line should be `\n` then `*` (the asterisk is `od`'s repeat marker for EOF).
+41 bytes: 40 hex + `\n`. No labels, no keys, no timestamp, no trailing text. Confirm with `od -c "$REVIEWS_DIR/{number}-rex.approved" | head -2` — the first two bytes of the second line should be `\n` then `*` (the asterisk is `od`'s repeat marker for EOF).
 
 #### WRONG — do NOT write any of these
 

--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -165,10 +165,13 @@ resolve_merge_repo() {
 #   OPS_FORK=$(find_ops_fork_root)
 find_ops_fork_root() {
   local r="$PWD"
-  while [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do
+  # Guard on [ -n "$r" ] to break out when r collapses to empty — which happens
+  # one iteration after r="/" because bash's `${r%/*}` on "/" is "". Without this
+  # guard the loop spins forever when onboarding.yaml isn't anywhere up the tree.
+  while [ -n "$r" ] && [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do
     r="${r%/*}"
   done
-  if [ -f "$r/onboarding.yaml" ]; then
+  if [ -n "$r" ] && [ -f "$r/onboarding.yaml" ]; then
     echo "$r"
   else
     echo ""

--- a/.claude/hooks/_lib-extract-pr.sh
+++ b/.claude/hooks/_lib-extract-pr.sh
@@ -113,3 +113,94 @@ resolve_pr_head() {
 
   echo "$sha"
 }
+
+# Echoes the `owner/repo` the merge command targets, or empty on failure.
+# Resolution order:
+#   1. Explicit `--repo <owner/repo>` flag on the command
+#   2. `repos/<owner>/<repo>/pulls/<N>/merge` URL path from the API shape
+#   3. `gh repo view --json nameWithOwner` — uses cwd's origin remote
+#
+# Why this exists (#7): merge-gate hooks previously resolved the marker dir
+# via `git rev-parse --show-toplevel`, which returns the cwd's git root —
+# not the repo the merge targets when `--repo` is used. That meant every
+# `gh pr merge <N> --repo <other>` required a `cd` to the right repo first.
+# This helper pulls the repo directly from the merge command, so marker
+# paths follow the target repo rather than the cwd.
+#
+# Usage:
+#   CMD_REPO=$(resolve_merge_repo "$COMMAND")
+resolve_merge_repo() {
+  local cmd="$1"
+  local repo=""
+
+  # 1. Explicit --repo flag
+  repo=$(echo "$cmd" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
+
+  # 2. API shape: repos/<owner>/<repo>/pulls/<N>/merge
+  if [ -z "$repo" ]; then
+    repo=$(echo "$cmd" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
+  fi
+
+  # 3. Ask gh for the cwd's default repo
+  if [ -z "$repo" ]; then
+    repo=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null)
+  fi
+
+  echo "$repo"
+}
+
+# Walks up from cwd until it finds a directory containing `onboarding.yaml`.
+# That's the ApexYard ops-fork root — where `.claude/hooks/`, `.claude/rules/`,
+# `.claude/session/reviews/`, etc. live. Returns empty if no onboarding.yaml
+# is found up to `/`.
+#
+# Why this exists (#7): marker files must live in a single canonical
+# location (the ops fork) so merges from any cwd — inside a managed repo's
+# workspace/, inside the ops fork itself, or a nested subdirectory — resolve
+# to the same `.claude/session/reviews/` tree. `git rev-parse --show-toplevel`
+# returns the *cwd's* repo root, which in a multi-managed-project setup is
+# usually wrong.
+#
+# Usage:
+#   OPS_FORK=$(find_ops_fork_root)
+find_ops_fork_root() {
+  local r="$PWD"
+  while [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do
+    r="${r%/*}"
+  done
+  if [ -f "$r/onboarding.yaml" ]; then
+    echo "$r"
+  else
+    echo ""
+  fi
+}
+
+# Echoes the absolute marker-directory path for a given `owner/repo`, anchored
+# at the ops-fork root. Creates a per-repo subdir so two managed repos that
+# both have a PR #4 don't collide on a single `4-*.approved` filename.
+#
+# Why this exists (#7): before this helper, markers lived flat under
+# `.claude/session/reviews/<N>-*.approved`, keyed only by PR number. Two
+# managed repos with a PR of the same number shared files — surfaced in
+# production on 2026-04-24 when `mrshousha/apexyard#4` (merged) left a stale
+# CEO marker at `4-ceo.approved` that then collided with `mrshousha/ravely#4`.
+#
+# The new scheme: `.claude/session/reviews/<owner>/<repo>/<N>-*.approved`.
+# Per-repo subdir, no collision, same number in different repos is fine.
+#
+# Usage:
+#   REVIEWS_DIR=$(reviews_dir "$OWNER_REPO")    # e.g. "mrshousha/ravely"
+#   # → /Users/.../apexyard/.claude/session/reviews/mrshousha/ravely
+reviews_dir() {
+  local owner_repo="$1"
+  local ops_fork
+  ops_fork=$(find_ops_fork_root)
+
+  if [ -z "$ops_fork" ] || [ -z "$owner_repo" ]; then
+    # Caller must fall back — no sane namespace available
+    echo ""
+    return
+  fi
+
+  echo "${ops_fork}/.claude/session/reviews/${owner_repo}"
+}

--- a/.claude/hooks/auto-code-review.sh
+++ b/.claude/hooks/auto-code-review.sh
@@ -8,9 +8,9 @@
 # into the conversation. Exit 2 does NOT roll back the PR — it just nudges
 # Claude to run the review immediately rather than "later".
 #
-# The marker file at .claude/session/pending-reviews/<pr> is also read by
-# the merge-gate hook so a PR cannot be merged without a corresponding Rex
-# approval file at .claude/session/reviews/<pr>-rex.approved.
+# Marker paths are per-repo to match the merge-gate hooks (#7):
+#   <ops-fork>/.claude/session/pending-reviews/<owner>/<repo>/<pr>
+#   <ops-fork>/.claude/session/reviews/<owner>/<repo>/<pr>-rex.approved
 
 INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
@@ -30,9 +30,14 @@ if ! echo "$COMMAND" | grep -qE '\bgh\s+pr\s+create\b'; then
   exit 0
 fi
 
-# Extract the PR URL from the tool output (gh prints the URL on success)
+# Source the shared lib for reviews_dir + find_ops_fork_root
+. "$(dirname "$0")/_lib-extract-pr.sh"
+
+# Extract the PR URL from the tool output (gh prints the URL on success).
+# URL shape: https://github.com/<owner>/<repo>/pull/<N>
 PR_URL=$(echo "$OUTPUT" | grep -oE 'https://github\.com/[^[:space:]]+/pull/[0-9]+' | head -1)
 PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+OWNER_REPO=$(echo "$PR_URL" | sed -nE 's|https://github\.com/([^/]+/[^/]+)/pull/[0-9]+|\1|p')
 
 if [ -z "$PR_NUMBER" ]; then
   PR_REF="the PR you just created"
@@ -40,10 +45,17 @@ else
   PR_REF="PR #$PR_NUMBER"
 fi
 
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-mkdir -p "${REPO_ROOT:-.}/.claude/session/pending-reviews"
-if [ -n "$PR_NUMBER" ]; then
-  echo "${PR_URL}" > "${REPO_ROOT:-.}/.claude/session/pending-reviews/${PR_NUMBER}"
+# Write the pending-review marker and compute the expected rex-approval path
+# under the per-repo namespace (#7). If we can't resolve the ops-fork or
+# owner/repo, fall back to a flat path so the hook still nudges Rex but the
+# merge gate will later print a clearer error.
+OPS_FORK=$(find_ops_fork_root)
+REX_PATH_HINT=".claude/session/reviews/${OWNER_REPO:-<owner/repo>}/${PR_NUMBER:-<pr>}-rex.approved"
+if [ -n "$OPS_FORK" ] && [ -n "$OWNER_REPO" ] && [ -n "$PR_NUMBER" ]; then
+  PENDING_DIR="${OPS_FORK}/.claude/session/pending-reviews/${OWNER_REPO}"
+  mkdir -p "$PENDING_DIR"
+  echo "${PR_URL}" > "${PENDING_DIR}/${PR_NUMBER}"
+  REX_PATH_HINT="${OPS_FORK}/.claude/session/reviews/${OWNER_REPO}/${PR_NUMBER}-rex.approved"
 fi
 
 cat >&2 <<MSG
@@ -55,10 +67,12 @@ and .claude/rules/pr-workflow.md. Invoke Rex NOW using the Agent tool:
 
   subagent_type: code-reviewer
   prompt: "Review ${PR_REF} at ${PR_URL}. Check the diff, tests, coverage,
-           AgDR linkage, glossary, and commit SHA consistency. Report verdict."
+           AgDR linkage, glossary, and commit SHA consistency. Report verdict.
+           Owner/repo: ${OWNER_REPO:-<owner/repo>}. Write the approval marker
+           at ${REX_PATH_HINT}."
 
 The merge-gate hook will block \`gh pr merge\` for this PR until a Rex approval
-file exists at .claude/session/reviews/${PR_NUMBER:-<pr>}-rex.approved.
+file exists at ${REX_PATH_HINT}.
 
 This message is a reminder from the PostToolUse hook, not a tool error. The PR
 was created successfully.

--- a/.claude/hooks/block-merge-on-red-ci.sh
+++ b/.claude/hooks/block-merge-on-red-ci.sh
@@ -42,13 +42,9 @@ if ! is_merge_command "$COMMAND"; then
   exit 0
 fi
 
-# Parse --repo (for `gh pr merge --repo owner/repo`). Fallback: recover from
-# the `gh api .../pulls/<N>/merge` URL path so `gh pr checks` below is still
-# scoped correctly.
-CMD_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
-if [ -z "$CMD_REPO" ]; then
-  CMD_REPO=$(echo "$COMMAND" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
-fi
+# Resolve target repo via the shared helper (handles --repo, API URL, and
+# cwd-origin fallback — see #7).
+CMD_REPO=$(resolve_merge_repo "$COMMAND")
 REPO_FLAG=""
 if [ -n "$CMD_REPO" ]; then
   REPO_FLAG="--repo $CMD_REPO"

--- a/.claude/hooks/block-unreviewed-merge.sh
+++ b/.claude/hooks/block-unreviewed-merge.sh
@@ -7,13 +7,14 @@
 #
 # Enforces workflow-gates rule #5 ("2 reviews — agent + human, CI green,
 # commit SHA matches review") at the merge boundary, mechanically. Two
-# markers are required:
+# markers are required, anchored per-repo under the ops fork (see #7 for
+# why per-repo namespacing replaced the old flat `<N>-*.approved` scheme):
 #
-#   .claude/session/reviews/<pr>-rex.approved
+#   <ops-fork>/.claude/session/reviews/<owner>/<repo>/<pr>-rex.approved
 #     Written by the code-reviewer agent (Rex) after a successful review.
 #     Contents: the commit SHA Rex reviewed.
 #
-#   .claude/session/reviews/<pr>-ceo.approved
+#   <ops-fork>/.claude/session/reviews/<owner>/<repo>/<pr>-ceo.approved
 #     Written ONLY by the /approve-merge <pr> skill on explicit user
 #     invocation. Contents: the commit SHA the CEO approved.
 #
@@ -46,15 +47,10 @@ if ! is_merge_command "$COMMAND"; then
   exit 0
 fi
 
-# Parse --repo (for `gh pr merge --repo owner/repo`). The API-shape encodes
-# the repo in its URL path so we don't need the flag there — downstream
-# `gh pr view` / `gh pr checks` calls still benefit when the flag was passed.
-CMD_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
-# If the command uses the API shape, recover owner/repo from the URL path
-# so other gh calls below can still be scoped correctly.
-if [ -z "$CMD_REPO" ]; then
-  CMD_REPO=$(echo "$COMMAND" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
-fi
+# Resolve the target repo of the merge (from --repo, the API URL, or the
+# cwd's origin). This is what the marker-path scheme keys on now, replacing
+# the old cwd-dependent `git rev-parse --show-toplevel` lookup (see #7).
+CMD_REPO=$(resolve_merge_repo "$COMMAND")
 
 PR_NUMBER=$(extract_pr_number "$COMMAND")
 
@@ -63,8 +59,16 @@ if [ -z "$PR_NUMBER" ]; then
   exit 2
 fi
 
-REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-REVIEWS_DIR="${REPO_ROOT:-.}/.claude/session/reviews"
+if [ -z "$CMD_REPO" ]; then
+  echo "BLOCKED: Could not determine target repo for merge. Pass --repo <owner/repo> or run inside a repo with a GitHub origin." >&2
+  exit 2
+fi
+
+REVIEWS_DIR=$(reviews_dir "$CMD_REPO")
+if [ -z "$REVIEWS_DIR" ]; then
+  echo "BLOCKED: Could not locate ops-fork root (no onboarding.yaml found walking up from $PWD). This hook requires an ApexYard ops fork above the cwd." >&2
+  exit 2
+fi
 REX_APPROVAL="${REVIEWS_DIR}/${PR_NUMBER}-rex.approved"
 CEO_APPROVAL="${REVIEWS_DIR}/${PR_NUMBER}-ceo.approved"
 
@@ -87,17 +91,17 @@ if [ ! -f "$REX_APPROVAL" ]; then
 BLOCKED: PR #${PR_NUMBER} has no recorded code-reviewer (Rex) approval.
 
 ApexYard requires two reviews before merge (workflow-gates rule #5):
-  1. Code Reviewer agent (Rex) — automated, recorded in .claude/session/reviews/
+  1. Code Reviewer agent (Rex) — automated, recorded in reviews/<owner>/<repo>/
   2. Human approver (CEO) — recorded by the /approve-merge skill
 
 Missing file:
   ${REX_APPROVAL}
 
 To unblock:
-  1. Invoke the code-reviewer agent on this PR
-  2. When Rex returns "approved", it records the approval automatically
-  3. Then run /approve-merge ${PR_NUMBER} for the CEO approval
-  4. Retry the merge
+  1. Invoke the code-reviewer agent on this PR (it writes the marker to the
+     per-repo path above — see .claude/agents/code-reviewer.md)
+  2. Then run /approve-merge ${PR_NUMBER} for the CEO approval
+  3. Retry the merge
 
 Never skip this check — even for typo fixes. See .claude/rules/pr-workflow.md.
 MSG

--- a/.claude/hooks/require-design-review-for-ui.sh
+++ b/.claude/hooks/require-design-review-for-ui.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # PreToolUse hook on `gh pr merge` AND `gh api .../pulls/<N>/merge`: when the
 # PR's diff touches UI files, require a design approval marker at
-# .claude/session/reviews/<pr>-design.approved (with a matching HEAD SHA) before
-# letting the merge through.
+# <ops-fork>/.claude/session/reviews/<owner>/<repo>/<pr>-design.approved
+# (with a matching HEAD SHA) before letting the merge through. See #7 for
+# the per-repo namespace change.
 #
 # Both merge shapes are covered — see _lib-extract-pr.sh for the parser and
 # #47 for why the API-shape bypass was a gap worth closing.
@@ -44,13 +45,9 @@ if ! is_merge_command "$COMMAND"; then
   exit 0
 fi
 
-# Parse --repo (for `gh pr merge --repo owner/repo`). Fallback: recover from
-# the `gh api .../pulls/<N>/merge` URL path so downstream `gh pr diff` calls
-# still know which repo to talk to.
-CMD_REPO=$(echo "$COMMAND" | sed -nE 's/.*--repo[[:space:]]+([^[:space:]]+).*/\1/p' | head -1)
-if [ -z "$CMD_REPO" ]; then
-  CMD_REPO=$(echo "$COMMAND" | grep -oE 'repos/[^/[:space:]]+/[^/[:space:]]+/pulls/[0-9]+/merge' | sed -nE 's|repos/([^/]+/[^/]+)/pulls/.*|\1|p' | head -1)
-fi
+# Resolve the merge's target repo via the shared helper — handles --repo flag,
+# API URL, and cwd-origin fallback (see #7).
+CMD_REPO=$(resolve_merge_repo "$COMMAND")
 REPO_FLAG=""
 if [ -n "$CMD_REPO" ]; then
   REPO_FLAG="--repo $CMD_REPO"
@@ -63,6 +60,9 @@ if [ -z "$PR_NUMBER" ]; then
   exit 0
 fi
 
+# Used only to look up .claude/project-config.json for UI-path overrides below
+# (per-project config is a per-repo concern, so this still wants the cwd's
+# git root, not the ops-fork root).
 REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 
 # Default UI path patterns (regex). Note: .tsx$ / .jsx$ are EXACT — they must
@@ -111,7 +111,12 @@ if [ -z "$TOUCHED_UI" ]; then
 fi
 
 # UI PR detected — require a design approval marker
-APPROVAL="${REPO_ROOT:-.}/.claude/session/reviews/${PR_NUMBER}-design.approved"
+REVIEWS_DIR=$(reviews_dir "$CMD_REPO")
+if [ -z "$REVIEWS_DIR" ]; then
+  echo "BLOCKED: Could not locate ops-fork root (no onboarding.yaml above $PWD) or target repo (pass --repo <owner/repo>). Design-review gate cannot resolve the marker path." >&2
+  exit 2
+fi
+APPROVAL="${REVIEWS_DIR}/${PR_NUMBER}-design.approved"
 
 if [ ! -f "$APPROVAL" ]; then
   cat >&2 <<MSG
@@ -130,9 +135,8 @@ The expected approval file does not exist:
 To unblock:
 
   1. Invoke the UI Designer role (or a human designer) to review the UI changes
-  2. When the designer approves, record it with the current HEAD SHA:
-       mkdir -p .claude/session/reviews
-       git rev-parse HEAD > .claude/session/reviews/${PR_NUMBER}-design.approved
+  2. When the designer approves, invoke /approve-design ${PR_NUMBER} — the skill
+     writes the marker to the per-repo path above
   3. Retry the merge
 
 To customize which file patterns count as "UI", set

--- a/.claude/rules/pr-workflow.md
+++ b/.claude/rules/pr-workflow.md
@@ -91,7 +91,7 @@ This also applies to other destructive / externally-visible / hard-to-reverse ac
 
 ### Mechanical enforcement
 
-The `block-unreviewed-merge.sh` hook enforces this rule at the shell level. It requires **two** approval markers in `.claude/session/reviews/` before letting any merge command through:
+The `block-unreviewed-merge.sh` hook enforces this rule at the shell level. It requires **two** approval markers in `<ops-fork>/.claude/session/reviews/<owner>/<repo>/` before letting any merge command through (see #7 for why the path is per-repo and anchored at the ops-fork root rather than flat under the cwd's git root):
 
 | Marker | Written by | Semantics |
 |--------|------------|-----------|

--- a/.claude/skills/approve-design/SKILL.md
+++ b/.claude/skills/approve-design/SKILL.md
@@ -75,7 +75,7 @@ If ambiguous, STOP and ask.
 Design review is a stamp on top of a Rex-approved HEAD, not parallel to code review. The marker lives at the ops-fork root, per-repo:
 
 ```bash
-OPS_FORK=$(r="$PWD"; while [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do r="${r%/*}"; done; echo "$r")
+OPS_FORK=$(r="$PWD"; while [ -n "$r" ] && [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do r="${r%/*}"; done; [ -n "$r" ] && [ -f "$r/onboarding.yaml" ] && echo "$r")
 REVIEWS_DIR="$OPS_FORK/.claude/session/reviews/<owner>/<repo>"
 REX="$REVIEWS_DIR/<pr>-rex.approved"
 PR_HEAD=$(gh pr view <pr> --repo <owner>/<repo> --json headRefOid --jq '.headRefOid')
@@ -97,7 +97,7 @@ gh pr diff <pr> --repo <owner>/<repo> --name-only | grep -qE '\.(tsx|jsx|vue|sve
 Anchor at the ops-fork root, not `git rev-parse --show-toplevel` — the cwd may be inside a different managed repo's workspace (see #7):
 
 ```bash
-OPS_FORK=$(r="$PWD"; while [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do r="${r%/*}"; done; echo "$r")
+OPS_FORK=$(r="$PWD"; while [ -n "$r" ] && [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do r="${r%/*}"; done; [ -n "$r" ] && [ -f "$r/onboarding.yaml" ] && echo "$r")
 REVIEWS_DIR="$OPS_FORK/.claude/session/reviews/<owner>/<repo>"
 mkdir -p "$REVIEWS_DIR"
 gh pr view <pr> --repo <owner>/<repo> --json headRefOid --jq '.headRefOid' \
@@ -106,7 +106,7 @@ gh pr view <pr> --repo <owner>/<repo> --json headRefOid --jq '.headRefOid' \
 
 The file contains exactly one line: the 40-character HEAD SHA.
 
-### 7. Confirm to the user
+### 8. Confirm to the user
 
 Output a single-line confirmation:
 

--- a/.claude/skills/approve-design/SKILL.md
+++ b/.claude/skills/approve-design/SKILL.md
@@ -98,13 +98,17 @@ Anchor at the ops-fork root, not `git rev-parse --show-toplevel` — the cwd may
 
 ```bash
 OPS_FORK=$(r="$PWD"; while [ -n "$r" ] && [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do r="${r%/*}"; done; [ -n "$r" ] && [ -f "$r/onboarding.yaml" ] && echo "$r")
+if [ -z "$OPS_FORK" ]; then
+  echo "ERROR: Could not locate ops-fork root (no onboarding.yaml above $PWD). /approve-design must run with an ApexYard ops fork on the walkup path." >&2
+  exit 1
+fi
 REVIEWS_DIR="$OPS_FORK/.claude/session/reviews/<owner>/<repo>"
 mkdir -p "$REVIEWS_DIR"
 gh pr view <pr> --repo <owner>/<repo> --json headRefOid --jq '.headRefOid' \
   > "$REVIEWS_DIR/<pr>-design.approved"
 ```
 
-The file contains exactly one line: the 40-character HEAD SHA.
+The file contains exactly one line: the 40-character HEAD SHA. The explicit `OPS_FORK` check above prevents the silent-failure mode where the skill "succeeds" but the marker lands somewhere the merge gate won't read.
 
 ### 8. Confirm to the user
 

--- a/.claude/skills/approve-design/SKILL.md
+++ b/.claude/skills/approve-design/SKILL.md
@@ -8,9 +8,9 @@ effort: low
 
 # /approve-design - Record Per-PR Design-Review Approval
 
-Writes `.claude/session/reviews/<pr>-design.approved` with the current HEAD SHA so the `require-design-review-for-ui.sh` merge-gate hook will let a UI PR through. Without this marker, the hook blocks merges on any PR that touches `.tsx`, `.jsx`, `.vue`, `.svelte`, `.css`, `.scss`, `.sass`, `.less`, or `design-tokens*` files.
+Writes `<ops-fork>/.claude/session/reviews/<owner>/<repo>/<pr>-design.approved` with the current HEAD SHA so the `require-design-review-for-ui.sh` merge-gate hook will let a UI PR through. Without this marker, the hook blocks merges on any PR that touches `.tsx`, `.jsx`, `.vue`, `.svelte`, `.css`, `.scss`, `.sass`, `.less`, or `design-tokens*` files.
 
-This skill is the design-review analog of `/approve-merge` (which writes the CEO marker for the merge gate). Same pattern, different gate.
+This skill is the design-review analog of `/approve-merge` (which writes the CEO marker for the merge gate). Same pattern, different gate. Markers are per-repo and anchored at the ops-fork root (see #7).
 
 ## The one rule you must not break
 
@@ -61,34 +61,47 @@ Run `gh pr view <pr> --json state,isDraft,mergeable`. Sanity checks:
 - Refuse if `MERGED`, `CLOSED`, or `DRAFT`.
 - `mergeable` should be `MERGEABLE` or `UNKNOWN`.
 
-### 4. Verify the Rex marker exists at current HEAD
+### 4. Resolve the target repo
 
-Design review is a stamp on top of a Rex-approved HEAD, not parallel to code review. Check (using an absolute path anchored at the repo root):
+The marker lives in a per-`<owner>/<repo>` subdir (see #7). Resolve the repo via:
+
+1. `gh pr view <pr> --json headRepositoryOwner,headRepository --jq '.headRepositoryOwner.login + "/" + .headRepository.name'`
+2. Or `gh pr view <pr> --repo <hint> --json headRepositoryOwner,headRepository --jq '...'` if a hint is available.
+
+If ambiguous, STOP and ask.
+
+### 5. Verify the Rex marker exists at current HEAD
+
+Design review is a stamp on top of a Rex-approved HEAD, not parallel to code review. The marker lives at the ops-fork root, per-repo:
 
 ```bash
-REPO_ROOT=$(git rev-parse --show-toplevel)
-REX="$REPO_ROOT/.claude/session/reviews/<pr>-rex.approved"
-[ -f "$REX" ] && [ "$(tr -d '[:space:]' < "$REX")" = "$(git rev-parse HEAD)" ]
+OPS_FORK=$(r="$PWD"; while [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do r="${r%/*}"; done; echo "$r")
+REVIEWS_DIR="$OPS_FORK/.claude/session/reviews/<owner>/<repo>"
+REX="$REVIEWS_DIR/<pr>-rex.approved"
+PR_HEAD=$(gh pr view <pr> --repo <owner>/<repo> --json headRefOid --jq '.headRefOid')
+[ -f "$REX" ] && [ "$(tr -d '[:space:]' < "$REX")" = "$PR_HEAD" ]
 ```
 
-If Rex's marker is missing or its SHA doesn't match HEAD, refuse and tell the user to re-invoke the code-reviewer first. Do not write the design marker on a stale base.
+If Rex's marker is missing or its SHA doesn't match the PR's HEAD, refuse and tell the user to re-invoke the code-reviewer first. Do not write the design marker on a stale base.
 
-### 5. Verify the PR actually touches UI files
+### 6. Verify the PR actually touches UI files
 
 Check whether the PR's diff includes files that would trigger the design-review gate. If the PR has NO UI files, the marker is unnecessary — tell the user and skip.
 
 ```bash
-gh pr diff <pr> --name-only | grep -qE '\.(tsx|jsx|vue|svelte|css|scss|sass|less)$|design-tokens'
+gh pr diff <pr> --repo <owner>/<repo> --name-only | grep -qE '\.(tsx|jsx|vue|svelte|css|scss|sass|less)$|design-tokens'
 ```
 
-### 6. Write the design marker
+### 7. Write the design marker
 
-Construct the path from the repo root (same lesson as `/approve-merge` — never use cwd-relative paths):
+Anchor at the ops-fork root, not `git rev-parse --show-toplevel` — the cwd may be inside a different managed repo's workspace (see #7):
 
 ```bash
-REPO_ROOT=$(git rev-parse --show-toplevel)
-mkdir -p "$REPO_ROOT/.claude/session/reviews"
-git rev-parse HEAD > "$REPO_ROOT/.claude/session/reviews/<pr>-design.approved"
+OPS_FORK=$(r="$PWD"; while [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do r="${r%/*}"; done; echo "$r")
+REVIEWS_DIR="$OPS_FORK/.claude/session/reviews/<owner>/<repo>"
+mkdir -p "$REVIEWS_DIR"
+gh pr view <pr> --repo <owner>/<repo> --json headRefOid --jq '.headRefOid' \
+  > "$REVIEWS_DIR/<pr>-design.approved"
 ```
 
 The file contains exactly one line: the 40-character HEAD SHA.
@@ -131,14 +144,14 @@ Two distinct moments. One is mockup approval (design phase). The other is implem
 
 ## Relationship to other approval skills
 
-| Skill | Marker | Gate hook | Who invokes |
-|-------|--------|-----------|-------------|
-| `/approve-merge` | `<pr>-ceo.approved` | `block-unreviewed-merge.sh` | On explicit CEO per-PR merge nod |
-| **`/approve-design`** | `<pr>-design.approved` | `require-design-review-for-ui.sh` | On explicit designer per-PR design nod |
+| Skill | Marker (per-repo) | Gate hook | Who invokes |
+|-------|-------------------|-----------|-------------|
+| `/approve-merge` | `reviews/<owner>/<repo>/<pr>-ceo.approved` | `block-unreviewed-merge.sh` | On explicit CEO per-PR merge nod |
+| **`/approve-design`** | `reviews/<owner>/<repo>/<pr>-design.approved` | `require-design-review-for-ui.sh` | On explicit designer per-PR design nod |
 
-Both skills follow the same pattern: verify PR state → verify Rex marker → write marker at repo root → confirm → stop. Both refuse to write on a stale Rex base. Both are invalidated by new commits. Neither runs `gh pr merge`.
+Both skills follow the same pattern: verify PR state → resolve target repo → verify Rex marker → write marker at the ops-fork root's per-repo subdir → confirm → stop. Both refuse to write on a stale Rex base. Both are invalidated by new commits. Neither runs `gh pr merge`.
 
-The merge flow for a UI PR requires **three** markers before the merge-gate hooks allow through:
+The merge flow for a UI PR requires **three** markers at `<ops-fork>/.claude/session/reviews/<owner>/<repo>/` before the merge-gate hooks allow through:
 
 1. `<pr>-rex.approved` — from the code-reviewer agent
 2. `<pr>-design.approved` — from this skill

--- a/.claude/skills/approve-merge/SKILL.md
+++ b/.claude/skills/approve-merge/SKILL.md
@@ -75,7 +75,7 @@ If resolution is ambiguous, STOP and ask.
 The CEO approval is a stamp on top of a Rex-approved HEAD, not a standalone action. The marker path is anchored at the ops-fork root, per-repo:
 
 ```bash
-OPS_FORK=$(r="$PWD"; while [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do r="${r%/*}"; done; echo "$r")
+OPS_FORK=$(r="$PWD"; while [ -n "$r" ] && [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do r="${r%/*}"; done; [ -n "$r" ] && [ -f "$r/onboarding.yaml" ] && echo "$r")
 REVIEWS_DIR="$OPS_FORK/.claude/session/reviews/<owner>/<repo>"
 REX="$REVIEWS_DIR/<pr>-rex.approved"
 PR_HEAD=$(gh pr view <pr> --repo <owner>/<repo> --json headRefOid --jq '.headRefOid')
@@ -89,7 +89,7 @@ If Rex's marker is missing or its SHA doesn't match the PR's HEAD, refuse and te
 Construct the marker path from the ops-fork root + the per-repo subdirectory. **Never** use `git rev-parse --show-toplevel` — that returns the cwd's git root, which is wrong when the skill is invoked from a workspace/managed-repo while merging a PR in a different repo. Bug #7 closed that hole.
 
 ```bash
-OPS_FORK=$(r="$PWD"; while [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do r="${r%/*}"; done; echo "$r")
+OPS_FORK=$(r="$PWD"; while [ -n "$r" ] && [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do r="${r%/*}"; done; [ -n "$r" ] && [ -f "$r/onboarding.yaml" ] && echo "$r")
 REVIEWS_DIR="$OPS_FORK/.claude/session/reviews/<owner>/<repo>"
 mkdir -p "$REVIEWS_DIR"
 # Use the PR's real HEAD, not local HEAD — local is rarely the PR branch
@@ -99,7 +99,7 @@ gh pr view <pr> --repo <owner>/<repo> --json headRefOid --jq '.headRefOid' \
 
 The file contains exactly one line: the 40-character HEAD SHA. A marker written to the wrong directory is a silent failure mode: the skill "succeeds", then the hook blocks with a confusing "CEO marker missing" error pointing at a path that technically exists somewhere else in the tree.
 
-### 6. Confirm to the user
+### 7. Confirm to the user
 
 Output a single-line confirmation:
 

--- a/.claude/skills/approve-merge/SKILL.md
+++ b/.claude/skills/approve-merge/SKILL.md
@@ -8,7 +8,9 @@ effort: low
 
 # /approve-merge - Record CEO Per-PR Merge Approval
 
-Writes `.claude/session/reviews/<pr>-ceo.approved` with the current HEAD SHA so the `block-unreviewed-merge.sh` hook will let a `gh pr merge` through. This is the **mechanical enforcement** of the "plan-level 'go' is not merge approval" rule in `.claude/rules/pr-workflow.md`.
+Writes `<ops-fork>/.claude/session/reviews/<owner>/<repo>/<pr>-ceo.approved` with the current HEAD SHA so the `block-unreviewed-merge.sh` hook will let a `gh pr merge` through. This is the **mechanical enforcement** of the "plan-level 'go' is not merge approval" rule in `.claude/rules/pr-workflow.md`.
+
+Markers are per-repo (owner/repo subdir) and anchored at the ops-fork root, so (a) two managed repos with the same PR number do not collide, and (b) markers are findable regardless of which repo's working tree the skill was invoked from. See #7 for the rationale and the bug the old flat scheme produced.
 
 ## The one rule you must not break
 
@@ -58,29 +60,44 @@ Run `gh pr view <pr> --json state,isDraft,mergeable,reviewDecision`. Sanity chec
 - `mergeable` should be `MERGEABLE` or `UNKNOWN` (GitHub hasn't computed yet). Refuse on `CONFLICTING`.
 - `reviewDecision` is informational — the Rex marker is the ground truth for "code-reviewer approved." If Rex hasn't approved yet, refuse (the merge hook will block anyway, but failing fast is kinder).
 
-### 4. Verify the Rex marker exists at current HEAD
+### 4. Resolve the target repo
 
-The CEO approval is a stamp on top of a Rex-approved HEAD, not a standalone action. Check (using an absolute path anchored at the repo root, not a cwd-relative path):
+The marker lives in a per-repo subdirectory. You need `<owner>/<repo>` — resolve in this order:
 
-```bash
-REPO_ROOT=$(git rev-parse --show-toplevel)
-REX="$REPO_ROOT/.claude/session/reviews/<pr>-rex.approved"
-[ -f "$REX" ] && [ "$(tr -d '[:space:]' < "$REX")" = "$(git rev-parse HEAD)" ]
-```
+1. The user's invocation if explicit: `/approve-merge <pr> --repo owner/repo` (future: skill doesn't parse flags yet; if you added one, read it here).
+2. `gh pr view <pr> --json headRepository,headRepositoryOwner --jq '.headRepositoryOwner.login + "/" + .headRepository.name'` — authoritative.
+3. Fallback: `gh repo view --json nameWithOwner --jq '.nameWithOwner'` in the cwd (only correct if cwd's origin matches the merge target — don't assume).
 
-If Rex's marker is missing or its SHA doesn't match HEAD, refuse and tell the user to re-invoke the code-reviewer first. Do not write the CEO marker on a stale base.
+If resolution is ambiguous, STOP and ask.
 
-### 5. Write the CEO marker
+### 5. Verify the Rex marker exists at current HEAD
 
-Construct the marker path from the repo root so it doesn't matter which subdirectory the skill was invoked from (you might be inside `workspace/<project>/` at the time). The `block-unreviewed-merge.sh` hook looks for markers at `$(git rev-parse --show-toplevel)/.claude/session/reviews/` — use the same anchor:
+The CEO approval is a stamp on top of a Rex-approved HEAD, not a standalone action. The marker path is anchored at the ops-fork root, per-repo:
 
 ```bash
-REPO_ROOT=$(git rev-parse --show-toplevel)
-mkdir -p "$REPO_ROOT/.claude/session/reviews"
-git rev-parse HEAD > "$REPO_ROOT/.claude/session/reviews/<pr>-ceo.approved"
+OPS_FORK=$(r="$PWD"; while [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do r="${r%/*}"; done; echo "$r")
+REVIEWS_DIR="$OPS_FORK/.claude/session/reviews/<owner>/<repo>"
+REX="$REVIEWS_DIR/<pr>-rex.approved"
+PR_HEAD=$(gh pr view <pr> --repo <owner>/<repo> --json headRefOid --jq '.headRefOid')
+[ -f "$REX" ] && [ "$(tr -d '[:space:]' < "$REX")" = "$PR_HEAD" ]
 ```
 
-The file contains exactly one line: the 40-character HEAD SHA. **Never use a cwd-relative path** — a marker written to the wrong directory is a silent failure mode: the skill "succeeds", then the hook still blocks the merge with a confusing "CEO marker missing" message pointing at a path that technically exists somewhere else in the tree.
+If Rex's marker is missing or its SHA doesn't match the PR's HEAD, refuse and tell the user to re-invoke the code-reviewer first. Do not write the CEO marker on a stale base.
+
+### 6. Write the CEO marker
+
+Construct the marker path from the ops-fork root + the per-repo subdirectory. **Never** use `git rev-parse --show-toplevel` — that returns the cwd's git root, which is wrong when the skill is invoked from a workspace/managed-repo while merging a PR in a different repo. Bug #7 closed that hole.
+
+```bash
+OPS_FORK=$(r="$PWD"; while [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do r="${r%/*}"; done; echo "$r")
+REVIEWS_DIR="$OPS_FORK/.claude/session/reviews/<owner>/<repo>"
+mkdir -p "$REVIEWS_DIR"
+# Use the PR's real HEAD, not local HEAD — local is rarely the PR branch
+gh pr view <pr> --repo <owner>/<repo> --json headRefOid --jq '.headRefOid' \
+  > "$REVIEWS_DIR/<pr>-ceo.approved"
+```
+
+The file contains exactly one line: the 40-character HEAD SHA. A marker written to the wrong directory is a silent failure mode: the skill "succeeds", then the hook blocks with a confusing "CEO marker missing" error pointing at a path that technically exists somewhere else in the tree.
 
 ### 6. Confirm to the user
 
@@ -98,6 +115,7 @@ CEO approval recorded for PR #<pr> at <sha>. You can now run: gh pr merge <pr>
 - Re-running `/approve-merge <pr>` on the same PR is idempotent — it overwrites the marker with the current HEAD, which is useful if the CEO re-approves after a rebase or a small follow-up.
 - New commits to the PR after the marker is written invalidate the approval: the hook will refuse to merge because the SHA no longer matches HEAD. This is intentional — review + approval are bound to a specific commit.
 - The skill intentionally does **not** automate "wait for the user's 'approved' and then run this." The skill exists to be invoked, not to poll.
+- Markers live under a per-`<owner>/<repo>` subdir (see #7) — two managed repos with the same PR number do not share a marker. The ops-fork root (detected via `onboarding.yaml` walkup) is the single anchor; the skill works the same whether invoked from the fork root, a `workspace/<project>/` subdirectory, or anywhere in between.
 
 ## Anti-pattern
 

--- a/.claude/skills/approve-merge/SKILL.md
+++ b/.claude/skills/approve-merge/SKILL.md
@@ -90,6 +90,10 @@ Construct the marker path from the ops-fork root + the per-repo subdirectory. **
 
 ```bash
 OPS_FORK=$(r="$PWD"; while [ -n "$r" ] && [ ! -f "$r/onboarding.yaml" ] && [ "$r" != "/" ]; do r="${r%/*}"; done; [ -n "$r" ] && [ -f "$r/onboarding.yaml" ] && echo "$r")
+if [ -z "$OPS_FORK" ]; then
+  echo "ERROR: Could not locate ops-fork root (no onboarding.yaml above $PWD). /approve-merge must run with an ApexYard ops fork on the walkup path." >&2
+  exit 1
+fi
 REVIEWS_DIR="$OPS_FORK/.claude/session/reviews/<owner>/<repo>"
 mkdir -p "$REVIEWS_DIR"
 # Use the PR's real HEAD, not local HEAD — local is rarely the PR branch
@@ -97,7 +101,7 @@ gh pr view <pr> --repo <owner>/<repo> --json headRefOid --jq '.headRefOid' \
   > "$REVIEWS_DIR/<pr>-ceo.approved"
 ```
 
-The file contains exactly one line: the 40-character HEAD SHA. A marker written to the wrong directory is a silent failure mode: the skill "succeeds", then the hook blocks with a confusing "CEO marker missing" error pointing at a path that technically exists somewhere else in the tree.
+The file contains exactly one line: the 40-character HEAD SHA. A marker written to the wrong directory is a silent failure mode: the skill "succeeds", then the hook blocks with a confusing "CEO marker missing" error pointing at a path that technically exists somewhere else in the tree. The explicit `OPS_FORK` check above prevents that silent-failure mode when the skill is somehow invoked outside the ops fork.
 
 ### 7. Confirm to the user
 


### PR DESCRIPTION
## Summary

Fixes two related merge-gate framework bugs surfaced during the Ravely bootstrap on 2026-04-24.

**Bug 1 — Marker namespace collision**: `.claude/session/reviews/<N>-*.approved` was keyed only by PR number, so two managed repos with the same PR number shared one file. `mrshousha/apexyard#4` (merged) left a stale CEO marker that collided with `mrshousha/ravely#4`'s merge.

**Bug 2 — Hook resolved marker dir from cwd, not `--repo`**: `block-unreviewed-merge.sh` used `git rev-parse --show-toplevel`, so `gh pr merge <N> --repo <other>` from a `workspace/<project>/` cwd looked in the wrong repo's marker tree.

## Fix (unified)

Markers now live at:

```
<ops-fork>/.claude/session/reviews/<owner>/<repo>/<pr>-{rex,ceo,design}.approved
```

- Per-repo subdir → no collision.
- Anchored at the ops-fork root (via `onboarding.yaml` walkup) → `--repo` is respected regardless of cwd.

Three new helpers in `_lib-extract-pr.sh`:

| Helper | Purpose |
|--------|---------|
| `find_ops_fork_root` | Walks up from cwd to the nearest `onboarding.yaml` |
| `resolve_merge_repo` | Reads `--repo` flag, API URL, or `gh repo view` fallback |
| `reviews_dir` | Combines the two into the per-repo marker path |

All consumers now delegate to these helpers — no hook reimplements `--repo` parsing inline.

## Files changed

- `.claude/hooks/_lib-extract-pr.sh` — new helpers
- `.claude/hooks/block-unreviewed-merge.sh` — uses new helpers; error messages updated
- `.claude/hooks/require-design-review-for-ui.sh` — same pattern for design marker
- `.claude/hooks/block-merge-on-red-ci.sh` — dedupe `--repo` parsing (this hook doesn't use markers)
- `.claude/hooks/auto-code-review.sh` — emits the per-repo marker path hint to Rex
- `.claude/skills/approve-merge/SKILL.md` — updated marker-writing instructions
- `.claude/skills/approve-design/SKILL.md` — updated marker-writing instructions
- `.claude/agents/code-reviewer.md` — updated marker-writing instructions
- `.claude/rules/pr-workflow.md` — canonical doc of the new marker scheme

## Testing

Manual verification via a test harness that exercises the helpers against four realistic scenarios (see commit message for details):

| Scenario | Expected | Result |
|---|---|---|
| Cross-repo merge: `gh pr merge 6 --repo mrshousha/apexyard` from `workspace/ravely/` cwd | Resolve to `apexyard` marker dir | ✓ |
| Same-repo merge with `--repo` | Resolve to the named repo | ✓ |
| API-shape: `gh api repos/mrshousha/ravely/pulls/4/merge` | Extract repo from URL | ✓ |
| No `--repo`, cwd fallback | Resolve to cwd's origin | ✓ |

No code-path regression tests exist for the hooks (the framework doesn't ship a hook-test harness), so smoke verification is the bar.

## No backwards compat

Session markers are gitignored per-machine state. Any in-flight merges (none expected — all outstanding PRs already merged) would re-run Rex + CEO under the new scheme.

## Follow-up

Consider a hook-test harness in a later PR — `bats` or similar — so future framework changes don't ship untested. Not a blocker.

Closes #7

## Glossary

| Term | Definition |
|------|------------|
| Ops fork | The fork of `me2resh/apexyard` (here: `mrshousha/apexyard`) that governs the managed portfolio. Identified by the presence of `onboarding.yaml` at its root. |
| Per-repo marker namespace | `.claude/session/reviews/<owner>/<repo>/<N>-*.approved` — the new scheme. Two managed repos with the same PR number no longer share files. |
| Managed repo | Any repo listed in `apexyard.projects.yaml`. Merges in managed repos flow through the same merge-gate hooks as ops-fork PRs. |
| Merge-gate hook | A PreToolUse hook on `gh pr merge` / `gh api .../merge` that blocks merges unless approval markers exist and match the PR's HEAD. There are three: unreviewed (Rex + CEO), red-CI, and design-review. |
| `resolve_merge_repo` | New helper in `_lib-extract-pr.sh` that extracts the merge's target `<owner>/<repo>` from the command — either the `--repo` flag, the REST-API URL path, or the cwd's origin as a fallback. |
| `find_ops_fork_root` | New helper that walks up from cwd to the first directory containing `onboarding.yaml`. This is the single anchor for all marker paths, replacing the old cwd-dependent `git rev-parse --show-toplevel` lookup. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)